### PR TITLE
Prevent excessive logging to the console

### DIFF
--- a/planout/experiment.py
+++ b/planout/experiment.py
@@ -237,6 +237,7 @@ class SimpleExperiment(Experiment):
       my_logger[self.name] = logging.getLogger(self.name)
       my_logger[self.name].setLevel(logging.INFO)
       my_logger[self.name].addHandler(logging.FileHandler(file_name))
+      my_logger[self.name].propagate = False
 
   def log(self, data):
     """Logs data to a file"""


### PR DESCRIPTION
This is a simple change that represents one way to make the IPython notebooks work for everyone when you demo it in the fashion used for PyData 2014. By default, all handled messages will be handled by the root logger as well, which is set by default to log to the console. It doesn't matter that the root logger is set to log only warnings.
