### PR TITLE
Weighted Choice cum_weights Hash not Array

### DIFF
--- a/alpha/ruby/lib/plan_out/op_random.rb
+++ b/alpha/ruby/lib/plan_out/op_random.rb
@@ -57,7 +57,7 @@ module PlanOut
 
       return [] if choices.length() == 0
 
-      cum_weights = choices.zip(weights)
+      cum_weights = Hash[choices.zip(weights)]
       cum_sum = 0.0
 
       cum_weights.each do |choice, weight|


### PR DESCRIPTION
I haven't written Ruby, but I think you want a Hash here, not an array. Looks like this was lost in translation from the Python --> Ruby port. 