### PR TITLE
resolve issue #43 - change assignment when salt setter called

### DIFF
--- a/python/planout/experiment.py
+++ b/python/planout/experiment.py
@@ -98,6 +98,7 @@ class Experiment(object):
     @salt.setter
     def salt(self, value):
         self._salt = value
+        self._assignment.experiment_salt = value
 
     @property
     def name(self):


### PR DESCRIPTION
I changed the experiment salt setter to update the assignment in the commit below. One question we will want to resolve before merging:

If the experiment_salt is based solely off the experiment name (salt setter has not been called) and someone calls the experiment name setter, should we update the Assignment salt as well?