### PR TITLE
update assignment when experiment name setter called

### DIFF
--- a/python/planout/experiment.py
+++ b/python/planout/experiment.py
@@ -107,6 +107,7 @@ class Experiment(object):
     @name.setter
     def name(self, value):
         self._name = re.sub(r'\s+', '-', value)
+        self._assignment.experiment_salt = self.salt
 
     @abstractmethod
     def assign(params, **kwargs):


### PR DESCRIPTION
Note that using the `self.salt` accessor will only update the assignment to the experiment name if the experiment salt is not defined.