### PR TITLE
Add Python 3 compatibility (requires six)

### DIFF
--- a/python/planout/experiment.py
+++ b/python/planout/experiment.py
@@ -12,6 +12,7 @@ import json
 import inspect
 import hashlib
 from abc import ABCMeta, abstractmethod
+import six
 import __main__ as main
 
 from .assignment import Assignment
@@ -137,6 +138,8 @@ class Experiment(object):
             # src doesn't count first line of code, which includes function
             # name
             src = ''.join(inspect.getsourcelines(self.assign)[0][1:])
+            if not isinstance(src, six.binary_type):
+                src = src.encode("ascii")
             return hashlib.sha1(src).hexdigest()[:8]
         # if we're running in an interpreter, don't worry about it
         else:
@@ -315,5 +318,8 @@ class SimpleInterpretedExperiment(SimpleExperiment):
     def checksum(self):
         # self.script must be a dictionary
         assert hasattr(self, 'script') and type(self.script) == dict
+        src = json.dumps(self.script)
 
-        return hashlib.sha1(json.dumps(self.script)).hexdigest()[:8]
+        if not isinstance(src, six.binary_type):
+            src = src.encode("ascii")
+        return hashlib.sha1(src).hexdigest()[:8]

--- a/python/planout/ops/base.py
+++ b/python/planout/ops/base.py
@@ -65,7 +65,7 @@ class PlanOutOp(object):
     def getArgList(self, name):
         arg = self.getArgMixed(name)
         assert isinstance(arg, (list, tuple)), \
-            "%s: %s must be a list." % (self.__class__, name) + str(type(arg))
+            "%s: %s must be a list." % (self.__class__, name)
         return arg
 
     def getArgMap(self, name):

--- a/python/planout/ops/base.py
+++ b/python/planout/ops/base.py
@@ -7,6 +7,7 @@
 
 import logging
 from abc import ABCMeta, abstractmethod
+import six
 
 from .utils import Operators
 
@@ -39,32 +40,32 @@ class PlanOutOp(object):
 
     def getArgInt(self, name):
         arg = self.getArgMixed(name)
-        assert isinstance(arg, (int, long)), \
+        assert isinstance(arg, six.integer_types), \
             "%s: %s must be an int." % (self.__class__, name)
         return arg
 
     def getArgFloat(self, name):
         arg = self.getArgMixed(name)
-        assert isinstance(arg, (int, long, float)), \
+        assert isinstance(arg, (six.integer_types, float)), \
             "%s: %s must be a number." % (self.__class__, name)
         return float(arg)
 
     def getArgString(self, name):
         arg = self.getArgMixed(name)
-        assert isinstance(arg, (str, unicode)), \
+        assert isinstance(arg, six.string_types), \
             "%s: %s must be a string." % (self.__class__, name)
         return arg
 
     def getArgNumeric(self, name):
         arg = self.getArgMixed(name)
-        assert isinstance(arg, (int, float, long)), \
+        assert isinstance(arg, (six.integer_types, float)), \
             "%s: %s must be a numeric." % (self.__class__, name)
         return arg
 
     def getArgList(self, name):
         arg = self.getArgMixed(name)
         assert isinstance(arg, (list, tuple)), \
-            "%s: %s must be a list." % (self.__class__, name)
+            "%s: %s must be a list." % (self.__class__, name) + str(type(arg))
         return arg
 
     def getArgMap(self, name):

--- a/python/planout/ops/core.py
+++ b/python/planout/ops/core.py
@@ -1,3 +1,5 @@
+import six
+
 from .base import (
     PlanOutOp,
     PlanOutOpSimple,
@@ -177,7 +179,7 @@ class Or(PlanOutOp):
 class Product(PlanOutOpCommutative):
 
     def commutativeExecute(self, values):
-        return reduce(lambda x, y: x * y, values)
+        return six.moves.reduce(lambda x, y: x * y, values)
 
     def pretty(self):
         values = Operators.strip_array(self.getArgList('values'))

--- a/python/planout/ops/random.py
+++ b/python/planout/ops/random.py
@@ -1,4 +1,5 @@
 import hashlib
+import six
 from .base import PlanOutOpSimple
 
 
@@ -21,6 +22,8 @@ class PlanOutOpRandom(PlanOutOpSimple):
             full_salt = '%s.%s' % (self.mapper.experiment_salt, salt)
         unit_str = '.'.join(map(str, self.getUnit(appended_unit)))
         hash_str = '%s.%s' % (full_salt, unit_str)
+        if not isinstance(hash_str, six.binary_type):
+            hash_str = hash_str.encode("ascii")
         return int(hashlib.sha1(hash_str).hexdigest()[:15], 16)
 
     def getUniform(self, min_val=0.0, max_val=1.0, appended_unit=None):
@@ -116,7 +119,7 @@ class Sample(PlanOutOpRandom):
         else:
             num_draws = len(choices)
 
-        for i in xrange(len(choices) - 1, 0, -1):
+        for i in six.moves.range(len(choices) - 1, 0, -1):
             j = self.getHash(i) % (i + 1)
             choices[i], choices[j] = choices[j], choices[i]
         return choices[:num_draws]

--- a/python/planout/test/test_core_ops.py
+++ b/python/planout/test/test_core_ops.py
@@ -6,6 +6,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 import unittest
+import six
 
 from planout.interpreter import (
     Interpreter,
@@ -122,7 +123,7 @@ class TestBasicOperators(unittest.TestCase):
         self.assertEquals(x, 43)
 
     def test_length(self):
-        arr = range(5)
+        arr = list(range(5))
         length_test = self.run_config_single({'op': 'length', 'value': arr})
         self.assertEquals(len(arr), length_test)
         length_test = self.run_config_single({'op': 'length', 'value': []})
@@ -190,7 +191,7 @@ class TestBasicOperators(unittest.TestCase):
         self.assertEquals(sum(arr), sum_test)
 
         product_test = self.run_config_single({'op': 'product', 'values': arr})
-        self.assertEquals(reduce(lambda x, y: x * y, arr), product_test)
+        self.assertEquals(six.moves.reduce(lambda x, y: x * y, arr), product_test)
 
     def test_binary_ops(self):
         eq = self.run_config_single({'op': 'equals', 'left': 1, 'right': 2})

--- a/python/planout/test/test_random_ops.py
+++ b/python/planout/test/test_random_ops.py
@@ -8,6 +8,7 @@
 from collections import Counter
 import unittest
 from math import sqrt
+import six
 
 from planout.ops.random import *
 from planout.assignment import Assignment
@@ -39,7 +40,7 @@ class TestRandomOperators(unittest.TestCase):
     def distributionTester(self, func, value_mass, N=1000):
         """Make sure an experiment object generates the desired frequencies"""
         # run N trials of f() with input i
-        xs = [func(i=i).get('x') for i in xrange(N)]
+        xs = [func(i=i).get('x') for i in six.moves.range(N)]
         value_density = TestRandomOperators.valueMassToDensity(value_mass)
 
         # test outcome frequencies against expected density
@@ -170,7 +171,7 @@ class TestRandomOperators(unittest.TestCase):
             value_density = TestRandomOperators.valueMassToDensity(value_mass)
 
             # compute N trials
-            xs_list = [func(i=i).get('x') for i in xrange(N)]
+            xs_list = [func(i=i).get('x') for i in six.moves.range(N)]
 
             # each xs is a row of the transpose of xs_list.
             # this is expected to have the same distribution as value_density

--- a/python/setup.py
+++ b/python/setup.py
@@ -10,6 +10,9 @@ setup(
         'planout.ops',
         'planout.test'
     ],
+    requires=[
+        'six'
+    ],
     url='http://pypi.python.org/pypi/PlanOut/',
     license='LICENSE',
     description='PlanOut is a framework for online field experimentation.',


### PR DESCRIPTION
All tests passed under Python 3.4.3 after reverting `557e8346804c7f005e1d9aa24281be04cf2c9e91`, as that commit broke tests for Python 2 as well.