### PR TITLE
Fixx issue presented in comment on commit 557e834

### DIFF
--- a/python/planout/experiment.py
+++ b/python/planout/experiment.py
@@ -98,7 +98,8 @@ class Experiment(object):
     @salt.setter
     def salt(self, value):
         self._salt = value
-        self._assignment.experiment_salt = value
+        if self._assignment:
+            self._assignment.experiment_salt = value
 
     @property
     def name(self):
@@ -107,7 +108,8 @@ class Experiment(object):
     @name.setter
     def name(self, value):
         self._name = re.sub(r'\s+', '-', value)
-        self._assignment.experiment_salt = self.salt
+        if self._assignment:
+            self._assignment.experiment_salt = self.salt
 
     @abstractmethod
     def assign(params, **kwargs):

--- a/python/planout/experiment.py
+++ b/python/planout/experiment.py
@@ -98,7 +98,7 @@ class Experiment(object):
     @salt.setter
     def salt(self, value):
         self._salt = value
-        if self._assignment:
+        if hasattr(self, '_assignment'):
             self._assignment.experiment_salt = value
 
     @property
@@ -108,7 +108,7 @@ class Experiment(object):
     @name.setter
     def name(self, value):
         self._name = re.sub(r'\s+', '-', value)
-        if self._assignment:
+        if hasattr(self, '_assignment'):
             self._assignment.experiment_salt = self.salt
 
     @abstractmethod


### PR DESCRIPTION
Stop `name()` and `salt()` setters from accessing assignment if doesn't exist (as presented in 557e834). I'm not sure why my unittest was (and still is) reporting valid tests for the current code but this should hopefully fix any potential issues.