### PR TITLE
move js submodule out of alpha

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	path = java
 	url = https://github.com/Glassdoor/planout4j.git
 [submodule "alpha/js"]
-	path = alpha/js
+	path = js
 	url = https://github.com/HubSpot/PlanOut.js


### PR DESCRIPTION
@eytan 

We've been using the JS version in production for about a month with no problems, so figured I would move it out of alpha.