### PR TITLE
Nuke useless variable in namespace.py

### DIFF
--- a/python/planout/namespace.py
+++ b/python/planout/namespace.py
@@ -162,7 +162,6 @@ class SimpleNamespace(Namespace):
 
     def _assign_experiment(self):
         "assign primary unit to an experiment"
-        in_experiment = False
         segment = self.get_segment()
         # is the unit allocated to an experiment?
         if segment in self.segment_allocations:


### PR DESCRIPTION
Removing as per discussed in
https://github.com/facebook/planout/commit/320b1a8bc59af74fc99b6cc4608e22ed4285cfa4#diff-f3230c29b515f7fad862482c1d5ab42dR159