### PR TITLE
Bump ruby gem version

### DIFF
--- a/alpha/ruby/lib/plan_out/version.rb
+++ b/alpha/ruby/lib/plan_out/version.rb
@@ -1,3 +1,3 @@
 module PlanOut
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end


### PR DESCRIPTION
bump ruby gem version from `0.1.1` to `0.1.2` so that we can release the new gem.

/cc: @eytan 