### PR TITLE
Add support for custom salts

### DIFF
--- a/python/planout/assignment.py
+++ b/python/planout/assignment.py
@@ -24,12 +24,22 @@ class Assignment(MutableMapping):
         self.experiment_salt = experiment_salt
         self._overrides = overrides.copy()
         self._data = overrides.copy()
+        self._salt_func = self._default_salt_func
 
     def evaluate(self, value):
         return value
 
     def get_overrides(self):
         return self._overrides
+
+    def _default_salt_func(self, experiment_salt, var_salt):
+        return '%s.%s.' % (experiment_salt, var_salt)
+
+    def get_salt(self, salt):
+        return self._salt_func(self.experiment_salt, salt)
+
+    def set_salt_func(self, func):
+        self._salt_func = func
 
     def set_overrides(self, overrides):
         # maybe this should be a deep copy?
@@ -38,7 +48,7 @@ class Assignment(MutableMapping):
             self._data[var] = self._overrides[var]
 
     def __setitem__(self, name, value):
-        if name in ('_data', '_overrides', 'experiment_salt'):
+        if name in ('_data', '_overrides', '_salt_func', 'experiment_salt'):
             self.__dict__[name] = value
             return
 

--- a/python/planout/ops/random.py
+++ b/python/planout/ops/random.py
@@ -16,12 +16,12 @@ class PlanOutOpRandom(PlanOutOpSimple):
 
     def getHash(self, appended_unit=None):
         if 'full_salt' in self.args:
-            full_salt = self.getArgString('full_salt')  # do typechecking
+            full_salt = self.getArgString('full_salt') + '.'  # do typechecking
         else:
-            salt = self.getArgString('salt')
-            full_salt = '%s.%s' % (self.mapper.experiment_salt, salt)
+            full_salt = self.mapper.get_salt(self.getArgString('salt'))
+
         unit_str = '.'.join(map(str, self.getUnit(appended_unit)))
-        hash_str = '%s.%s' % (full_salt, unit_str)
+        hash_str = '%s%s' % (full_salt, unit_str)
         if not isinstance(hash_str, six.binary_type):
             hash_str = hash_str.encode("ascii")
         return int(hashlib.sha1(hash_str).hexdigest()[:15], 16)

--- a/python/planout/test/test_assignment.py
+++ b/python/planout/test/test_assignment.py
@@ -37,6 +37,11 @@ class AssignmentTest(unittest.TestCase):
         self.assertEqual(a.x, 42)
         self.assertEqual(a.y, 43)
 
+    def test_custom_salt(self):
+        a = Assignment(self.tester_salt)
+	custom_salt = lambda x,y: '%s-%s' % (x,y)
+        a.foo = UniformChoice(choices=range(8), unit=self.tester_unit)
+        self.assertEqual(a.foo, 7)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This allows developers to use hash salts in their production systems
that differ from the default PlanOut salting procedure.