### PR TITLE
Add ability to register third-party operators

### DIFF
--- a/python/planout/interpreter.py
+++ b/python/planout/interpreter.py
@@ -29,6 +29,10 @@ class Interpreter(object):
         self._in_experiment = True
         self._inputs = inputs.copy()
 
+    def register_operators(self, operators):
+        Operators.registerOperators(operators)
+        return self
+
     def get_params(self):
         """Get all assigned parameter values from an executed interpreter script"""
         # evaluate code if it hasn't already been evaluated

--- a/python/planout/ops/utils.py
+++ b/python/planout/ops/utils.py
@@ -1,4 +1,5 @@
 import json
+import six
 
 
 class StopPlanOutException(Exception):
@@ -10,6 +11,7 @@ class StopPlanOutException(Exception):
 
 
 class Operators():
+    """Singleton class for inspecting and registering operators"""
 
     @staticmethod
     def initFactory():
@@ -51,6 +53,12 @@ class Operators():
             "weightedChoice": random.WeightedChoice,
             "sample": random.Sample
         }
+
+    @staticmethod
+    def registerOperators(operators):
+        for op, obj in six.iteritems(operators):
+            assert op not in Operators.operators
+            Operators.operators[op] = operators[op]
 
     @staticmethod
     def isOperator(op):

--- a/python/planout/test/test_interpreter.py
+++ b/python/planout/test/test_interpreter.py
@@ -38,6 +38,20 @@ class InterpreterTest(unittest.TestCase):
         proc.set_overrides({'userid': 123454})
         self.assertEqual(proc.get_params().get('specific_goal'), 1)
 
+    def test_register_ops(self):
+        from planout.ops.base import PlanOutOpCommutative
+        class CustomOp(PlanOutOpCommutative):
+            def commutativeExecute(self, values):
+                return sum(values)
+
+        custom_op_script = {"op":"seq","seq":[{"op":"set","var":"x","value":{"values":[2,4],"op":"customOp"}}]}
+        proc = Interpreter(
+            custom_op_script, self.interpreter_salt, {'userid': 123454})
+
+        proc.register_operators({'customOp': CustomOp})
+        self.assertEqual(proc.get_params().get('x'), 6)
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Production experimentation stacks often rely on external services, like
gating infrastructure or data stores that include user characteristics.
Presently, there is no way to add additional operators without
modifying the Python codebase itself.

This patch makes it possible to register third-party operators with the
PlanOut operator utility class, which makes it possible to add
operators with a standard installation of PlanOut.