### PR TITLE
Clean up custom salts

### DIFF
--- a/python/planout/assignment.py
+++ b/python/planout/assignment.py
@@ -24,22 +24,13 @@ class Assignment(MutableMapping):
         self.experiment_salt = experiment_salt
         self._overrides = overrides.copy()
         self._data = overrides.copy()
-        self._salt_func = self._default_salt_func
+        self.salt_sep = '.' # separates unit from experiment/variable salt
 
     def evaluate(self, value):
         return value
 
     def get_overrides(self):
         return self._overrides
-
-    def _default_salt_func(self, experiment_salt, var_salt):
-        return '%s.%s.' % (experiment_salt, var_salt)
-
-    def get_salt(self, salt):
-        return self._salt_func(self.experiment_salt, salt)
-
-    def set_salt_func(self, func):
-        self._salt_func = func
 
     def set_overrides(self, overrides):
         # maybe this should be a deep copy?
@@ -48,7 +39,7 @@ class Assignment(MutableMapping):
             self._data[var] = self._overrides[var]
 
     def __setitem__(self, name, value):
-        if name in ('_data', '_overrides', '_salt_func', 'experiment_salt'):
+        if name in ('_data', '_overrides', 'salt_sep', 'experiment_salt'):
             self.__dict__[name] = value
             return
 

--- a/python/planout/interpreter.py
+++ b/python/planout/interpreter.py
@@ -46,6 +46,10 @@ class Interpreter(object):
     def in_experiment(self):
         return self._in_experiment
 
+    @property
+    def salt_sep(self):
+        return self._env.salt_sep
+
     def set_env(self, new_env):
         """Replace the current environment with a dictionary"""
         self._env = deepcopy(new_env)

--- a/python/planout/ops/random.py
+++ b/python/planout/ops/random.py
@@ -18,7 +18,10 @@ class PlanOutOpRandom(PlanOutOpSimple):
         if 'full_salt' in self.args:
             full_salt = self.getArgString('full_salt') + '.'  # do typechecking
         else:
-            full_salt = self.mapper.get_salt(self.getArgString('salt'))
+            full_salt = '%s.%s%s' % (
+                self.mapper.experiment_salt,
+                self.getArgString('salt'),
+                self.mapper.salt_sep)
 
         unit_str = '.'.join(map(str, self.getUnit(appended_unit)))
         hash_str = '%s%s' % (full_salt, unit_str)


### PR DESCRIPTION
The salt separator functionality added yesterday was kind of hacky and
didn't play nice with the Interpreter.  This implementation is shorter,
more Pythonic, and works well with Interpreter.