### PR TITLE
Fix inconsistent space/tab usage and range() for Python 3

### DIFF
--- a/python/planout/test/test_assignment.py
+++ b/python/planout/test/test_assignment.py
@@ -39,8 +39,8 @@ class AssignmentTest(unittest.TestCase):
 
     def test_custom_salt(self):
         a = Assignment(self.tester_salt)
-	custom_salt = lambda x,y: '%s-%s' % (x,y)
-        a.foo = UniformChoice(choices=range(8), unit=self.tester_unit)
+        custom_salt = lambda x,y: '%s-%s' % (x,y)
+        a.foo = UniformChoice(choices=list(range(8)), unit=self.tester_unit)
         self.assertEqual(a.foo, 7)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixed errors when running tests:

```
_______________ ERROR collecting planout/test/test_assignment.py _______________
/usr/lib/python3.5/site-packages/_pytest/python.py:611: in _importtestmodule
    mod = self.fspath.pyimport(ensuresyspath=importmode)
/usr/lib/python3.5/site-packages/py/_path/local.py:650: in pyimport
    __import__(modname)
E     File "/build/python-planout/src/planout/python/planout/test/test_assignment.py", line 42
E       custom_salt = lambda x,y: '%s-%s' % (x,y)
E                                               ^
E   TabError: inconsistent use of tabs and spaces in indentation
```

and

```
=================================== FAILURES ===================================
_______________________ AssignmentTest.test_custom_salt ________________________

self = <planout.test.test_assignment.AssignmentTest testMethod=test_custom_salt>

    def test_custom_salt(self):
        a = Assignment(self.tester_salt)
        custom_salt = lambda x,y: '%s-%s' % (x,y)
>       a.foo = UniformChoice(choices=range(8), unit=self.tester_unit)

test_assignment.py:43:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../assignment.py:52: in __setitem__
    self._data[name] = value.execute(self)
../ops/base.py:97: in execute
    return self.simpleExecute()
../ops/random.py:84: in simpleExecute
    choices = self.getArgList('choices')
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <planout.ops.random.UniformChoice object at 0x7fe4e8ee9ba8>
name = 'choices'

    def getArgList(self, name):
        arg = self.getArgMixed(name)
        assert isinstance(arg, (list, tuple)), \
>           "%s: %s must be a list." % (self.__class__, name)
E       AssertionError: <class 'planout.ops.random.UniformChoice'>: choices must be a list.

../ops/base.py:68: AssertionError
```