### PR TITLE
Make gh-pages compatible with Jekyll 3.0 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,12 +4,12 @@ url: http://facebook.github.io
 permalink: /blog/:year/:month/:day/:title.html
 name: PlanOut
 relative_permalinks: false
-markdown: redcarpet
 description: A framework for online field experiments
+gems: [jekyll-paginate]
 paginate: 5
 paginate_path: /blog/page:num/
 timezone: America/Los_Angeles
 
 safe: true
 lsi: false
-pygments: true
+highlighter: rouge

--- a/index.md
+++ b/index.md
@@ -68,7 +68,7 @@ For an in-depth look at how we use PlanOut at Facebook, see our paper, [Designin
 In addition to the Python reference implementation written by Facebook, there are
 multiple third party ports of PlanOut.
 
-Production-ready ports of PlanOut of PlanOut are available at:
+Production-ready ports of PlanOut are available at:
 
   * [Java](https://github.com/Glassdoor/planout4j): full-featured implementation of PlanOut by Glassdoor,
  including experiment lifecycle management and code review.


### PR DESCRIPTION
`jekyll serve` now runs + creates site without build errors. 

https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0

Also fixed a small typo