### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,9 @@ If you are planning on porting PlanOut to other languages or platforms,
 please let us know! We are happy to review ports in detail, and either post
 them on our own repository, or link to your own repository as a submodule.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
 ## Our Development Process
 The Python reference implementation mirrors the functionality of PlanOut and
 core parts of Facebook's experimentation stack, which is written in Hack (we


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the planout community profile](https://github.com/facebook/planout/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1304" alt="screen shot 2017-11-26 at 2 03 19 pm" src="https://user-images.githubusercontent.com/1114467/33244810-bf39ab88-d2b2-11e7-8367-535a664957a3.png">
<img width="1313" alt="screen shot 2017-11-26 at 2 03 32 pm" src="https://user-images.githubusercontent.com/1114467/33244811-bf541414-d2b2-11e7-8396-e0be58933cde.png">


**issue:**
internal task t23481323