### PR TITLE
Update SimpleNamespace.setup_experiments signature.

### DIFF
--- a/python/planout/namespace.py
+++ b/python/planout/namespace.py
@@ -95,7 +95,7 @@ class SimpleNamespace(Namespace):
         pass
 
     @abstractmethod
-    def setup_experiments():
+    def setup_experiments(self):
         # e.g.,
         # self.add_experiment('first experiment', Exp1, 100)
         pass


### PR DESCRIPTION
The signature for setup_experiments of SimpleNamespace could be updated. 
Signature of method 'xxxxNamespace.setup_experiments()' does not match signature of base method in class 'SimpleNamespace', coz we need add experiment.