### PR TITLE
Make open graph description more accurate

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,7 +9,7 @@
     <meta name='viewport' content='width=device-width'>
     <meta property='og:type' content='website'>
     <meta property="og:title" content="PlanOut | {{ page.title }}" />
-    <meta property='og:description' content='PlanOut makes it easy to design and implement sophisticated randomized experiments in Python.'>
+    <meta property='og:description' content='PlanOut makes it easy to design and implement sophisticated randomized experiments in various web programming languages.'>
     <meta property='og:image' content='http://eytan.github.io/planout/static/og_dice.png'>
 
     <script>


### PR DESCRIPTION
This updates the description to acknowledge that Planout is available
for multiple web platforms. Since this field is used by applications
that unfurl links, often a misleading statement that this is a Python
library is inserted.