### PR TITLE
Fix test for Python 2.7

### DIFF
--- a/python/planout/test/test_namespace.py
+++ b/python/planout/test/test_namespace.py
@@ -1,10 +1,10 @@
 import unittest
 
 from planout.namespace import SimpleNamespace
-from planout.experiment import Experiment, DefaultExperiment
+from planout.experiment import DefaultExperiment
 
 
-class VanillaExperiment(Experiment):
+class VanillaExperiment(DefaultExperiment):
     def setup(self):
         self.name = 'test_name'
 


### PR DESCRIPTION
For Python 2.7, would get "TypeError: Can't instantiate abstract class VanillaExperiment with abstract methods configure_logger, log, previously_logged". This fixes to use `DefaultExperiment` base class.