### PR TITLE
Extend planout interpreter for python

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "alpha/golang"]
-	path = alpha/golang
-	url = https://github.com/URXtech/planout-golang
 [submodule "java"]
 	path = java
 	url = https://github.com/Glassdoor/planout4j

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/URXtech/planout-golang
 [submodule "java"]
 	path = java
-	url = https://github.com/Glassdoor/planout4j.git
+	url = https://github.com/Glassdoor/planout4j
 [submodule "alpha/js"]
 	path = js
 	url = https://github.com/HubSpot/PlanOut.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python:
   - 2.7
-  - 3.2
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/python/planout/ops/core.py
+++ b/python/planout/ops/core.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 import six
+from math import exp, sqrt
 
 from .base import (
     PlanOutOp,
@@ -292,3 +293,13 @@ class Length(PlanOutOpUnary):
 
     def unaryExecute(self, value):
         return len(value)
+
+class Exp(PlanOutOpUnary):
+
+    def unaryExecute(self, value):
+        return exp(value)
+
+class Sqrt(PlanOutOpUnary):
+
+    def unaryExecute(self, value):
+        return sqrt(value)

--- a/python/planout/ops/core.py
+++ b/python/planout/ops/core.py
@@ -1,8 +1,5 @@
 from copy import deepcopy
-from math import (
-    exp, 
-    sqrtg,
-)
+from math import exp, sqrt
 import six
 
 

--- a/python/planout/ops/core.py
+++ b/python/planout/ops/core.py
@@ -1,6 +1,8 @@
 from copy import deepcopy
+from math import exp
+from math import sqrt
 import six
-from math import exp, sqrt
+
 
 from .base import (
     PlanOutOp,

--- a/python/planout/ops/core.py
+++ b/python/planout/ops/core.py
@@ -1,6 +1,8 @@
 from copy import deepcopy
-from math import exp
-from math import sqrt
+from math import (
+    exp, 
+    sqrtg,
+)
 import six
 
 

--- a/python/planout/ops/utils.py
+++ b/python/planout/ops/utils.py
@@ -43,6 +43,8 @@ class Operators():
             "coalesce": core.Coalesce,
             "product": core.Product,
             "sum": core.Sum,
+            "exp": core.Exp,
+            "sqrt": core.Sqrt,
             "randomFloat": random.RandomFloat,
             "randomInteger": random.RandomInteger,
             "bernoulliTrial": random.BernoulliTrial,

--- a/python/planout/test/test_core_ops.py
+++ b/python/planout/test/test_core_ops.py
@@ -258,6 +258,35 @@ class TestBasicOperators(unittest.TestCase):
         i = return_runner(0)
         self.assertEquals({'x': 2}, i.get_params())
         self.assertEquals(False, i.in_experiment)
+    
+    def test_exp(self):
+        # test exp
+        x = self.run_config_single({'op': 'exp', 'value': 1})
+        self.assertEqual(2.718281828459045, x)
+
+        x = self.run_config_single({'op': 'exp', 'value': -0.5})
+        self.assertEqual(0.6065306597126334, x)
+
+        x = self.run_config_single({'op': 'exp', 'value': 0.123})
+        self.assertEqual(1.1308844209474893, x)
+
+        x = self.run_config_single({'op': 'exp', 'value': 1.88})
+        self.assertEqual(6.553504862191148, x)
+
+    
+    def test_sqrt(self):
+        # test sqrt
+        x = self.run_config_single({'op': 'sqrt', 'value': 1})
+        self.assertEqual(1, x)
+
+        with self.assertRaises(ValueError):
+            x = self.run_config_single({'op': 'sqrt', 'value': -0.5})
+        
+        x = self.run_config_single({'op': 'sqrt', 'value': 0.123})
+        self.assertEqual(0.3507135583350036, x)
+
+        x = self.run_config_single({'op': 'sqrt', 'value': 1.88})
+        self.assertEqual(1.3711309200802089, x)
 
 
 if __name__ == '__main__':

--- a/python/planout/test/test_core_ops.py
+++ b/python/planout/test/test_core_ops.py
@@ -222,6 +222,34 @@ class TestBasicOperators(unittest.TestCase):
         div = self.run_config_single({'op': '/', 'left': 3, 'right': 4})
         self.assertEquals(0.75, div)
 
+    def test_exp(self):
+        # test exp operator
+        x = self.run_config_single({'op': 'exp', 'value': 1})
+        self.assertEqual(2.718281828459045, x)
+
+        x = self.run_config_single({'op': 'exp', 'value': -0.5})
+        self.assertEqual(0.6065306597126334, x)
+
+        x = self.run_config_single({'op': 'exp', 'value': 0.123})
+        self.assertEqual(1.1308844209474893, x)
+
+        x = self.run_config_single({'op': 'exp', 'value': 1.88})
+        self.assertEqual(6.553504862191148, x)
+
+    def test_sqrt(self):
+        # test sqrt operator
+        x = self.run_config_single({'op': 'sqrt', 'value': 1})
+        self.assertEqual(1, x)
+
+        with self.assertRaises(ValueError):
+            x = self.run_config_single({'op': 'sqrt', 'value': -0.5})
+
+        x = self.run_config_single({'op': 'sqrt', 'value': 0.123})
+        self.assertEqual(0.3507135583350036, x)
+
+        x = self.run_config_single({'op': 'sqrt', 'value': 1.88})
+        self.assertEqual(1.3711309200802089, x)
+
     def test_return(self):
         def return_runner(return_value):
             config = {
@@ -258,36 +286,6 @@ class TestBasicOperators(unittest.TestCase):
         i = return_runner(0)
         self.assertEquals({'x': 2}, i.get_params())
         self.assertEquals(False, i.in_experiment)
-    
-    def test_exp(self):
-        # test exp
-        x = self.run_config_single({'op': 'exp', 'value': 1})
-        self.assertEqual(2.718281828459045, x)
-
-        x = self.run_config_single({'op': 'exp', 'value': -0.5})
-        self.assertEqual(0.6065306597126334, x)
-
-        x = self.run_config_single({'op': 'exp', 'value': 0.123})
-        self.assertEqual(1.1308844209474893, x)
-
-        x = self.run_config_single({'op': 'exp', 'value': 1.88})
-        self.assertEqual(6.553504862191148, x)
-
-    
-    def test_sqrt(self):
-        # test sqrt
-        x = self.run_config_single({'op': 'sqrt', 'value': 1})
-        self.assertEqual(1, x)
-
-        with self.assertRaises(ValueError):
-            x = self.run_config_single({'op': 'sqrt', 'value': -0.5})
-        
-        x = self.run_config_single({'op': 'sqrt', 'value': 0.123})
-        self.assertEqual(0.3507135583350036, x)
-
-        x = self.run_config_single({'op': 'sqrt', 'value': 1.88})
-        self.assertEqual(1.3711309200802089, x)
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Extend planout interpreter for python to have sum and sqrt.
This is related to this issues:
1. [Extending the Interpreter to Use Sqrt and Exp Operator.](https://github.com/facebook/planout/issues/147)
2. [Example for online evaluation.](https://github.com/facebook/Ax/issues/77)