### PR TITLE
Replace bare except clause to be more specific what type of exception it catches.

### DIFF
--- a/python/planout/ops/utils.py
+++ b/python/planout/ops/utils.py
@@ -92,7 +92,7 @@ class Operators():
             try:
                 # if an op is invalid, we may not be able to pretty print it
                 my_pretty = Operators.operatorInstance(params).pretty()
-            except:
+            except AssertionError:
                 my_pretty = params
             return my_pretty
         elif type(params) is list:


### PR DESCRIPTION
In accordance with [PEP 8](https://www.python.org/dev/peps/pep-0008/) you should mention exceptions when possible when using the `except:` clause, from what I'm able to see this should only catch AssertionError exceptions.