### PR TITLE
Mark 3.6 compatibility in setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -27,6 +27,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        "Programming Language :: Python :: 3.6",
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Testing',
     ],


### PR DESCRIPTION
3.6 is in the build matrix, so probably makes sense to add it here in the setup.py too.